### PR TITLE
Broken down internals (modules per "feature")

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,17 +54,6 @@ the message,
 * `passed_through`: an indication of whether or not the received message was passed through to
 the mocked process.
 
-## Caveats
-
-`nuntius` tries to execute your expectations by simply calling their declarations inside a
-`try-catch` expression. Because of this, non-matching expectations will return a `function_clause`,
-that is caught.
-Since it's not possible (at this moment) to distinguish a `function_clause` provoked by `nuntius`'
-internal code or your own, we propose you to make sure your functions don't fail with a
-`function_clause`.
-You can also check the message history to understand if a given message was mocked and/or
-passed through.
-
 ## Documentation
 
 Documentation is generated with:

--- a/code.dict
+++ b/code.dict
@@ -2,4 +2,5 @@
 gen_server
 new/2
 named_exp2
-
+function_clause
+lists,sort,[fff

--- a/nuntius.dict
+++ b/nuntius.dict
@@ -5,3 +5,4 @@ github
 pid
 rebar3
 todo
+e.g

--- a/src/nuntius.erl
+++ b/src/nuntius.erl
@@ -1,26 +1,28 @@
 %% @doc The main interface for the system.
 -module(nuntius).
 
--export([start/0, stop/0]).
--export([new/1, new/2, delete/1]).
--export([mocked/0, mocked_process/1]).
--export([passthrough/0, passthrough/1, mocked_process/0]).
+-export([delete/1, mocked/0, new/1, new/2]).
+-export([delete/2, expect/2, expect/3, expects/1]).
 -export([history/1, received/2, reset_history/1]).
--export([expect/2, expect/3, delete/2, expects/1]).
+-export([mocked_process/0, passthrough/0, passthrough/1]).
+-export([mocked_process/1]).
+-export([start/0, stop/0]).
 
--type process_name() :: atom().
 -type event() ::
     #{timestamp := integer(),
-      message := term(),
+      message := message(),
       mocked := boolean(),
       passed_through := boolean()}.
--type opts() :: #{passthrough => boolean(), history => boolean()}.
 -type expect_fun() :: fun((_) -> _).
--type expect_name() :: atom().
 -type expect_id() :: reference() | expect_name().
+-type expect_name() :: atom().
+-type message() :: term().
+-type opts() :: #{passthrough => boolean(), history => boolean()}.
+-type process_name() :: atom().
 
--export_type([process_name/0, opts/0, event/0]).
--export_type([expect_fun/0, expect_name/0, expect_id/0]).
+-export_type([event/0, expect_fun/0, expect_id/0]).
+-export_type([expect_name/0, message/0, opts/0]).
+-export_type([process_name/0]).
 
 %% @doc Starts the application.
 %% @equiv application:ensure_all_started(nuntius)
@@ -74,41 +76,41 @@ mocked() ->
 %% @doc Returns the PID of a mocked process (the original one with that name).
 -spec mocked_process(process_name()) -> pid() | {error, not_mocked}.
 mocked_process(ProcessName) ->
-    if_mocked(ProcessName, fun nuntius_mocker:mocked_process/1).
+    if_mocked(ProcessName, fun nuntius_mocker:process/1).
 
 %% @doc Passes the current message down to the mocked process.<br />
 %% <b>Note</b>: this code should only be used inside an expect fun.
 -spec passthrough() -> ok.
 passthrough() ->
-    nuntius_mocker:passthrough().
+    nuntius_proc:passthrough().
 
 %% @doc Passes a message down to the mocked process.<br />
 %% <b>Note</b>: this code should only be used inside an expect fun.
--spec passthrough(term()) -> ok.
+-spec passthrough(message()) -> ok.
 passthrough(Message) ->
-    nuntius_mocker:passthrough(Message).
+    nuntius_proc:passthrough(Message).
 
 %% @doc Returns the PID of the currently mocked process.<br />
 %% <b>Note</b>: this code should only be used inside an expect fun.
 -spec mocked_process() -> pid().
 mocked_process() ->
-    nuntius_mocker:mocked_process().
+    nuntius_proc:process().
 
 %% @doc Returns the history of messages received by a mocked process.
 -spec history(process_name()) -> [event()] | {error, not_mocked}.
 history(ProcessName) ->
-    if_mocked(ProcessName, fun nuntius_mocker:history/1).
+    if_mocked(ProcessName, fun nuntius_history:get/1).
 
 %% @doc Returns whether a particular message was received already.<br />
 %% <b>Note</b>: it only works with <code>history => true.</code>
--spec received(process_name(), term()) -> boolean() | {error, not_mocked}.
+-spec received(process_name(), message()) -> boolean() | {error, not_mocked}.
 received(ProcessName, Message) ->
-    if_mocked(ProcessName, fun(PN) -> nuntius_mocker:received(PN, Message) end).
+    if_mocked(ProcessName, fun(PN) -> nuntius_history:received(PN, Message) end).
 
 %% @doc Erases the history for a mocked process.
 -spec reset_history(process_name()) -> ok | {error, not_mocked}.
 reset_history(ProcessName) ->
-    if_mocked(ProcessName, fun nuntius_mocker:reset_history/1).
+    if_mocked(ProcessName, fun nuntius_history:reset/1).
 
 %% @doc Adds a new expect function to a mocked process.<br />
 %%      When a message is received by the process, this function will be run on it.<br />
@@ -134,7 +136,7 @@ expect(ProcessName, ExpectName, Function) ->
 do_expect(ProcessName, ExpectId, Function) ->
     if_mocked(ProcessName,
               fun(PN) ->
-                 nuntius_mocker:expect(PN, ExpectId, Function),
+                 nuntius_expect:save(PN, ExpectId, Function),
                  ExpectId
               end).
 
@@ -143,13 +145,13 @@ do_expect(ProcessName, ExpectId, Function) ->
 %%      If the process is not mocked, an error is returned.
 -spec delete(process_name(), expect_id()) -> ok | {error, not_mocked}.
 delete(ProcessName, ExpectId) ->
-    if_mocked(ProcessName, fun(PN) -> nuntius_mocker:delete(PN, ExpectId) end).
+    if_mocked(ProcessName, fun(PN) -> nuntius_expect:delete(PN, ExpectId) end).
 
 %% @doc Returns the list of expect functions for a process.
 -spec expects(process_name()) -> Expectations | {error, not_mocked}
     when Expectations :: #{expect_id() => expect_fun()}.
 expects(ProcessName) ->
-    if_mocked(ProcessName, fun nuntius_mocker:expects/1).
+    if_mocked(ProcessName, fun nuntius_expect:list/1).
 
 if_mocked(ProcessName, Function) ->
     case lists:member(ProcessName, mocked()) of

--- a/src/nuntius.erl
+++ b/src/nuntius.erl
@@ -94,7 +94,7 @@ passthrough(Message) ->
 %% <b>Note</b>: this code should only be used inside an expect fun.
 -spec mocked_process() -> pid().
 mocked_process() ->
-    nuntius_proc:process().
+    nuntius_proc:pid().
 
 %% @doc Returns the history of messages received by a mocked process.
 -spec history(process_name()) -> [event()] | {error, not_mocked}.

--- a/src/nuntius_expect.erl
+++ b/src/nuntius_expect.erl
@@ -1,0 +1,21 @@
+%% @hidden
+-module(nuntius_expect).
+
+-export([delete/2]).
+-export([list/1]).
+-export([save/3]).
+
+%% @doc Adds a new expect function to a mocked process.
+-spec save(nuntius:process_name(), nuntius:expect_id(), nuntius:expect_fun()) -> ok.
+save(ProcessName, ExpectId, Function) ->
+    nuntius_mocker:cast(ProcessName, {expect, Function, ExpectId}).
+
+%% @doc Removes an expect function.
+-spec delete(nuntius:process_name(), nuntius:expect_id()) -> ok.
+delete(ProcessName, ExpectId) ->
+    nuntius_mocker:cast(ProcessName, {delete, ExpectId}).
+
+%% @doc Returns the list of expect functions for a process.
+-spec list(nuntius:process_name()) -> #{nuntius:expect_id() => nuntius:expect_fun()}.
+list(ProcessName) ->
+    nuntius_mocker:call(ProcessName, expects).

--- a/src/nuntius_history.erl
+++ b/src/nuntius_history.erl
@@ -1,0 +1,23 @@
+%% @hidden
+-module(nuntius_history).
+
+-export([get/1]).
+-export([received/2]).
+-export([reset/1]).
+
+%% @doc Returns the history of messages received by a mocked process.
+-spec get(nuntius:process_name()) -> [nuntius:event()].
+get(ProcessName) ->
+    nuntius_mocker:call(ProcessName, history).
+
+%% @doc Returns whether a particular message was received already.
+-spec received(nuntius:process_name(), term()) -> boolean().
+received(ProcessName, Message) ->
+    nuntius_mocker:call(ProcessName, {received, Message}).
+
+%% @doc Erases the history for a mocked process.
+%%      Note that there is no gen:cast(...),
+%%      gen_server and others basically just send the message and move on, like us.
+-spec reset(nuntius:process_name()) -> ok.
+reset(ProcessName) ->
+    nuntius_mocker:cast(ProcessName, reset_history).

--- a/src/nuntius_mocker.erl
+++ b/src/nuntius_mocker.erl
@@ -1,11 +1,21 @@
 %% @hidden
 -module(nuntius_mocker).
 
--export([start_link/2]).
--export([mocked_process/1, history/1, received/2, reset_history/1, delete/1]).
--export([passthrough/0, passthrough/1, mocked_process/0]).
--export([expect/3, delete/2, expects/1]).
--export([init/3]).
+-export([call/2, cast/2]).
+-export([delete/1, process/1]).
+-export([init/3, start_link/2]).
+
+%% @doc Sends an asynchronous request to the mocker.
+-spec cast(nuntius:process_name(), nuntius:message()) -> ok.
+cast(ProcessName, Message) ->
+    ProcessName ! {'$nuntius_cast', Message},
+    ok.
+
+%% @doc Makes a synchronous request to the mocker.
+-spec call(nuntius:process_name(), nuntius:message()) -> term().
+call(ProcessName, Message) ->
+    {ok, Result} = gen:call(ProcessName, '$nuntius_call', Message),
+    Result.
 
 %% @doc Boots up a mocking process.
 %%      If the process to be mocked doesn't exist, returns <pre>ignore</pre>.
@@ -21,79 +31,23 @@ start_link(ProcessName, Opts) ->
 %% @doc Reregisters the mocked process with its name, thus removing the mock.
 -spec delete(nuntius:process_name()) -> ok.
 delete(ProcessName) ->
-    reregister(ProcessName, mocked_process(ProcessName)).
+    reregister(ProcessName, process(ProcessName)).
 
 %% @doc Returns the PID of a mocked process (the original one with that name).
--spec mocked_process(nuntius:process_name()) -> pid().
-mocked_process(ProcessName) ->
+-spec process(nuntius:process_name()) -> pid().
+process(ProcessName) ->
     {dictionary, Dict} = erlang:process_info(whereis(ProcessName), dictionary),
-    {'$nuntius_mocker_mocked_process', ProcessPid} =
-        lists:keyfind('$nuntius_mocker_mocked_process', 1, Dict),
+    {'$nuntius_mocker_process', ProcessPid} =
+        lists:keyfind('$nuntius_mocker_process', 1, Dict),
     ProcessPid.
-
-%% @doc Passes the current message down to the mocked process.
--spec passthrough() -> ok.
-passthrough() ->
-    passthrough(current_message()).
-
-%% @doc Passes a message down to the mocked process.
--spec passthrough(term()) -> ok.
-passthrough(Message) ->
-    ProcessPid = process_pid(),
-    passed_through(true),
-    ProcessPid ! Message.
-
-%% @doc Returns the PID of the currently mocked process.
--spec mocked_process() -> pid().
-mocked_process() ->
-    process_pid().
-
-%% @doc Returns the history of messages received by a mocked process.
--spec history(nuntius:process_name()) -> [nuntius:event()].
-history(ProcessName) ->
-    {ok, History} = gen:call(ProcessName, '$nuntius_call', history),
-    History.
-
-%% @doc Returns whether a particular message was received already.
--spec received(nuntius:process_name(), term()) -> boolean().
-received(ProcessName, Message) ->
-    {ok, Result} = gen:call(ProcessName, '$nuntius_call', {received, Message}),
-    Result.
-
-%% @doc Erases the history for a mocked process.
-%%      Note that there is no gen:cast(...),
-%%      gen_server and others basically just send the message and move on, like us.
--spec reset_history(nuntius:process_name()) -> ok.
-reset_history(ProcessName) ->
-    ProcessName ! {'$nuntius_cast', reset_history},
-    ok.
-
-%% @doc Adds a new expect function to a mocked process.
--spec expect(nuntius:process_name(), nuntius:expect_id(), nuntius:expect_fun()) -> ok.
-expect(ProcessName, ExpectId, Function) ->
-    ProcessName ! {'$nuntius_cast', {expect, Function, ExpectId}},
-    ok.
-
-%% @doc Removes an expect function.
--spec delete(nuntius:process_name(), nuntius:expect_id()) -> ok.
-delete(ProcessName, ExpectId) ->
-    ProcessName ! {'$nuntius_cast', {delete, ExpectId}},
-    ok.
-
-%% @doc Returns the list of expect functions for a process.
--spec expects(nuntius:process_name()) ->
-                 {ok, #{nuntius:expect_id() => nuntius:expect_fun()}}.
-expects(ProcessName) ->
-    {ok, Result} = gen:call(ProcessName, '$nuntius_call', expects),
-    Result.
 
 -spec init(nuntius:process_name(), pid(), nuntius:opts()) -> no_return().
 init(ProcessName, ProcessPid, Opts) ->
     ProcessMonitor = erlang:monitor(process, ProcessPid),
     reregister(ProcessName, self()),
-    erlang:put('$nuntius_mocker_mocked_process', ProcessPid),
+    erlang:put('$nuntius_mocker_process', ProcessPid),
     proc_lib:init_ack({ok, self()}),
-    process_pid(ProcessPid),
+    nuntius_proc:process(ProcessPid),
     loop(#{process_name => ProcessName,
            process_monitor => ProcessMonitor,
            history => [],
@@ -102,7 +56,7 @@ init(ProcessName, ProcessPid, Opts) ->
 
 %% @todo Verify if, on process termination, we need to do something more than just dying.
 loop(State) ->
-    ProcessPid = process_pid(),
+    ProcessPid = nuntius_proc:process(),
     #{process_monitor := ProcessMonitor} = State,
     NextState =
         receive
@@ -138,8 +92,8 @@ handle_cast({delete, ExpectId}, #{expects := Expects} = State) ->
     State#{expects => maps:remove(ExpectId, Expects)}.
 
 handle_message(Message, #{expects := Expects} = State) ->
-    current_message(Message),
-    passed_through(false),
+    nuntius_proc:current_message(Message),
+    nuntius_proc:passed_through(false),
     ExpectsMatched = run_expects(Message, Expects),
     _ = maybe_passthrough(Message, ExpectsMatched, State),
     maybe_add_event({Message, ExpectsMatched}, State).
@@ -163,15 +117,15 @@ maybe_passthrough(_Message, {{'$nuntius', match}, _}, _Opts) ->
 maybe_passthrough(_Message, _ExpectsMatched, #{opts := #{passthrough := false}}) ->
     {'$nuntius', ignore};
 maybe_passthrough(Message, _ExpectsMatched, _State) ->
-    passthrough(Message).
+    nuntius_proc:passthrough(Message).
 
 maybe_add_event(_Message, #{opts := #{history := false}} = State) ->
     State;
 maybe_add_event({Message, ExpectsMatched}, State) ->
     maps:update_with(history,
                      fun(History) ->
-                        PassedThrough = passed_through(),
-                        passed_through(false),
+                        PassedThrough = nuntius_proc:passed_through(),
+                        nuntius_proc:passed_through(false),
                         [#{timestamp => erlang:system_time(),
                            message => Message,
                            mocked => ExpectsMatched =/= {'$nuntius', nomatch},
@@ -179,21 +133,3 @@ maybe_add_event({Message, ExpectsMatched}, State) ->
                          | History]
                      end,
                      State).
-
-process_pid(ProcessPid) ->
-    put(process_pid, ProcessPid).
-
-process_pid() ->
-    get(process_pid).
-
-current_message(Message) ->
-    put(current_message, Message).
-
-current_message() ->
-    get(current_message).
-
-passed_through(Flag) ->
-    put(passed_through, Flag).
-
-passed_through() ->
-    get(passed_through).

--- a/src/nuntius_mocker.erl
+++ b/src/nuntius_mocker.erl
@@ -47,7 +47,7 @@ init(ProcessName, ProcessPid, Opts) ->
     reregister(ProcessName, self()),
     erlang:put('$nuntius_mocker_process', ProcessPid),
     proc_lib:init_ack({ok, self()}),
-    nuntius_proc:process(ProcessPid),
+    nuntius_proc:pid(ProcessPid),
     loop(#{process_name => ProcessName,
            process_monitor => ProcessMonitor,
            history => [],
@@ -56,7 +56,7 @@ init(ProcessName, ProcessPid, Opts) ->
 
 %% @todo Verify if, on process termination, we need to do something more than just dying.
 loop(State) ->
-    ProcessPid = nuntius_proc:process(),
+    ProcessPid = nuntius_proc:pid(),
     #{process_monitor := ProcessMonitor} = State,
     NextState =
         receive

--- a/src/nuntius_proc.erl
+++ b/src/nuntius_proc.erl
@@ -1,0 +1,39 @@
+%% @hidden
+-module(nuntius_proc).
+
+-export([current_message/0, current_message/1]).
+-export([passed_through/0, passed_through/1]).
+-export([passthrough/0, passthrough/1]).
+-export([process/0, process/1]).
+
+%% @doc Passes the current message down to the mocked process.
+-spec passthrough() -> ok.
+passthrough() ->
+    passthrough(current_message()).
+
+%% @doc Passes a message down to the mocked process.
+-spec passthrough(term()) -> ok.
+passthrough(Message) ->
+    ProcessPid = process(),
+    passed_through(true),
+    ProcessPid ! Message.
+
+%% @doc Returns the PID of the currently mocked process.
+-spec process() -> pid().
+process() ->
+    get(process_pid).
+
+process(ProcessPid) ->
+    put(process_pid, ProcessPid).
+
+current_message() ->
+    get(current_message).
+
+current_message(Message) ->
+    put(current_message, Message).
+
+passed_through(Flag) ->
+    put(passed_through, Flag).
+
+passed_through() ->
+    get(passed_through).

--- a/src/nuntius_proc.erl
+++ b/src/nuntius_proc.erl
@@ -4,7 +4,7 @@
 -export([current_message/0, current_message/1]).
 -export([passed_through/0, passed_through/1]).
 -export([passthrough/0, passthrough/1]).
--export([process/0, process/1]).
+-export([pid/0, pid/1]).
 
 %% @doc Passes the current message down to the mocked process.
 -spec passthrough() -> ok.
@@ -14,16 +14,16 @@ passthrough() ->
 %% @doc Passes a message down to the mocked process.
 -spec passthrough(term()) -> ok.
 passthrough(Message) ->
-    ProcessPid = process(),
+    ProcessPid = pid(),
     passed_through(true),
     ProcessPid ! Message.
 
 %% @doc Returns the PID of the currently mocked process.
--spec process() -> pid().
-process() ->
+-spec pid() -> pid().
+pid() ->
     get(process_pid).
 
-process(ProcessPid) ->
+pid(ProcessPid) ->
     put(process_pid, ProcessPid).
 
 current_message() ->

--- a/src/nuntius_sup.erl
+++ b/src/nuntius_sup.erl
@@ -4,9 +4,8 @@
 
 -behaviour(supervisor).
 
--export([start_link/0]).
+-export([init/1, start_link/0]).
 -export([mocked/0]).
--export([init/1]).
 -export([start_mock/2, stop_mock/1]).
 
 -spec start_link() -> {ok, pid()} | {error, term()}.

--- a/test/nuntius_api_SUITE.erl
+++ b/test/nuntius_api_SUITE.erl
@@ -21,6 +21,7 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(Config) ->
+    nuntius:stop(),
     Config.
 
 init_per_testcase(_TestCase, Config) ->

--- a/test/nuntius_api_SUITE.erl
+++ b/test/nuntius_api_SUITE.erl
@@ -305,7 +305,7 @@ call(Process, Message) ->
     receive
         {Ref, Result} ->
             Result
-    after 1000 ->
+    after 250 ->
         error(#{reason => timeout,
                 process => Process,
                 message => Message})


### PR DESCRIPTION
Fixes #33.

If you feel we should also sort the function definitions, I'm up for it.
I usually keep the "internal" functions next to whatever calls them (it seems you do the same), so I would be careful to take those along with the "moved" functions.

Let me know.