### PR TITLE
Add more information to history: return values and exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,15 @@ classified as per [Understanding the message history](#understanding-the-message
 
 ## Understanding the message history
 
-History elements are classified with 4 keys:
+History elements are classified with 6 keys:
 
 * `timestamp`: an integer representing Erlang system time in native time unit,
 * `message`: the message that was received and/or potentially handled by expectations
 (or passed through),
 * `mocked`: an indication of whether or not any of the expecations you declared handled
 the message,
+* `with`: the expectation return value,
+* `stack`: the stack trace, in case of an exception,
 * `passed_through`: an indication of whether or not the received message was passed through to
 the mocked process.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ processes, as well as other elements for debugging:
 * `passthrough`: when `true` (default: `true`) all messages received by the mock process are
 passed through to the mocked process,
 * `history`: when `true` (default: `true`) all messages received by the mock process are
-classified as per [Understanding the message history](#understanding-the-message-history).
+classified as per [Understanding the message history](#understanding-the-message-history),
+* `exit_on_nomatch`: (default: `true`) check [Expectation handling](#expectation-handling) below.
 
 ## Understanding the message history
 

--- a/src/nuntius.erl
+++ b/src/nuntius.erl
@@ -12,6 +12,8 @@
     #{timestamp := integer(),
       message := message(),
       mocked := boolean(),
+      with := term(),
+      stack := term(),
       passed_through := boolean()}.
 -type expect_fun() :: fun((_) -> _).
 -type expect_id() :: reference() | expect_name().

--- a/src/nuntius_mocker.erl
+++ b/src/nuntius_mocker.erl
@@ -117,11 +117,11 @@ run_expects(Message, Expects0, #{exit_on_nomatch := ExitOnNoMatch}) ->
                     end,
                     matched_with_stack(false, undefined, undefined),
                     Expects),
-    Matched = maps:get(matched, ExpectsMatched),
-    With = maps:get(with, ExpectsMatched, undefined),
-    StackTrace = maps:get(stack, ExpectsMatched),
-    case {Matched, With, StackTrace} of
-        {false, undefined, StackTrace} when ExitOnNoMatch ->
+    case ExpectsMatched of
+        #{matched := false,
+          with := undefined,
+          stack := StackTrace}
+            when ExitOnNoMatch ->
             exit({nuntius, nomatch, StackTrace});
         _Other ->
             ExpectsMatched


### PR DESCRIPTION
Closes #41.

* `with` will contain the expectation's return value (`undefined` if none)
* `stack` will contain a possible exception stacktrace (`undefined` if none)